### PR TITLE
Scheduler wrapper objects are never reused

### DIFF
--- a/lib/async/scheduler.rb
+++ b/lib/async/scheduler.rb
@@ -31,6 +31,8 @@ module Async
 				false
 			end
 		end
+
+		attr_reader :wrappers
 		
 		def initialize(reactor)
 			@reactor = reactor
@@ -51,6 +53,7 @@ module Async
 		end
 		
 		private def from_io(io)
+			puts "Scheduler#from_io io object_id: #{io.object_id}, fileno #{io.fileno}"
 			@wrappers[io] ||= Wrapper.new(io, @reactor)
 		end
 		


### PR DESCRIPTION
It seems scheduler wrapper objects memoized in `@wrappers` are never reused 😕
I think that means `@wrapper` currently just leaks memory, without any benefits of reusing `Wrapper` objects.

Output from `puts` debug statements (with comments):

```
input object_id: 2480, fileno 12                                  <= this IO should get into Scheduler 5 times
output object_id: 2500, fileno 13
Scheduler#from_io io object_id: 2520, fileno 12       <= Scheduler always receives a different object (based on object_id)
Scheduler#from_io io object_id: 2540, fileno 12
Scheduler#from_io io object_id: 2560, fileno 12
Scheduler#from_io io object_id: 2580, fileno 12
Scheduler#from_io io object_id: 2600, fileno 12
```

The above output shows `Scheduler#from_io` always receives a different `io` object (same file descriptor tho).
`@wrappers` hash grows on every invocation of `Scheduler#from_io`.
At the end of the spec from this PR `@wrappers` contains 5 objects.